### PR TITLE
Removed hyphens behind subsplit names in graph labels and comparison display

### DIFF
--- a/components/AttemptOverview.vue
+++ b/components/AttemptOverview.vue
@@ -121,7 +121,8 @@ export default class AttemptOverview extends Vue {
       this.AttemptSplitTimes,
       this.run.Segments.Segment.map(segment => {
         const time = selectTime((segment.SegmentHistory?.Time || []).find(t => t['@_id'] == this.attempt['@_id']));
-        return time ? `${segment.Name} (${formatTime(time)})` : segment.Name;
+        const segmentName = String(segment.Name);
+        return time ? `${segmentName.startsWith('-') ? segmentName.substring(1) : segmentName} (${formatTime(time)})` : segment.Name;
       }),
       false
     );
@@ -131,7 +132,8 @@ export default class AttemptOverview extends Vue {
     const labels = this.run.Segments.Segment.map((segment, i) => {
       // We need to introduce this variable otherwise TS is too dumb to realise that what we're doing is safe
       const ast = this.attemptSplitTimesaves[i];
-      return `${segment.Name} (${ast ? secondsToFormattedString(ast) : ''})`;
+      const segmentName = String(segment.Name);
+      return `${segmentName.startsWith('-') ? segmentName.substring(1) : segmentName} (${ast ? secondsToFormattedString(ast) : ''})`;
     });
 
     return this.makePlotData(

--- a/components/ComparisonsDisplay.vue
+++ b/components/ComparisonsDisplay.vue
@@ -49,6 +49,10 @@ export default class ComparisonsDisplay extends Vue {
 
   cumulateTime: boolean = true;
 
+  subsplitLabel(name: String) {
+    return(name.startsWith('-') ? (name.substring(1) + " (subsplit)") : name);
+  }
+
   get comparisonColumns() {
     return [this.referenceComparison, ...this.otherComparisons];
   }
@@ -82,7 +86,7 @@ export default class ComparisonsDisplay extends Vue {
   }
 
   get tableData() {
-    const out: any = this.segments.Segment.map(s => ({split: s.Name}));
+    const out: any = this.segments.Segment.map(s => ({split: this.subsplitLabel(s.Name)}));
 
     let timeSoFar = 0;
     const timesSoFarOthers: Record<string, number> = {};


### PR DESCRIPTION
<img width="430" alt="kp" src="https://user-images.githubusercontent.com/71961459/166214709-cd878d06-34bb-4981-9014-600b134db9de.png">
Subsplits in comparisons look something like this now, maybe it would be better to have something similar to what it shows in individual split analysis, or a tooltip when you hover over the split name, idk.