### PR TITLE
Fixed moveTime breaking best segments and SoB

### DIFF
--- a/components/modals/MoveTimeModal.vue
+++ b/components/modals/MoveTimeModal.vue
@@ -96,19 +96,20 @@ export default class MoveTimeModal extends mixins(BaseModal) {
 
   chosenSplitFunction() {
     if (this.transferSplit.id === this.currentSplitIndex + 1)
-      this.doMoveTime(this.currentSplit, this.nextSplit);
+      this.doMoveTime(this.currentSplit, this.nextSplit, true);
 
     if (this.transferSplit.id === this.currentSplitIndex - 1)
-      this.doMoveTime(this.currentSplit, this.previousSplit);
+      this.doMoveTime(this.currentSplit, this.previousSplit, false);
   }
 
-  doMoveTime(currentSplit: Segment, otherSplit: Segment) {
+  doMoveTime(currentSplit: Segment, otherSplit: Segment, nextSplit: boolean) {
     withLoad(() =>
       offload(
         OffloadWorkerOperation.MOVE_TIME_TO_OTHER_SPLIT,
         currentSplit,
         otherSplit,
-        this.transferTime
+        this.transferTime,
+        nextSplit
       ).then(modifiedSplits => {
         splitFileIsModified(true);
 

--- a/util/splitProcessing.ts
+++ b/util/splitProcessing.ts
@@ -37,7 +37,7 @@ const moveTransferTime = (chosenTime: OptionalRealAndGameTime, transferTime: num
   }
 };
 
-export const moveTime = (currentSplit: Segment, otherSplit: Segment, transferTime: number): Segment[] => {
+export const moveTime = (currentSplit: Segment, otherSplit: Segment, transferTime: number, nextSplit: boolean): Segment[] => {
   const currentSplitTimes       = currentSplit.SegmentHistory?.Time;
   const otherSplitTimes         = otherSplit.SegmentHistory?.Time;
   const currentSplitComparisons = currentSplit.SplitTimes.SplitTime;
@@ -50,10 +50,14 @@ export const moveTime = (currentSplit: Segment, otherSplit: Segment, transferTim
 
   otherSplitTimes?.forEach((attemptOtherSplit) => moveTransferTime(attemptOtherSplit, transferTime));
 
-  currentSplitComparisons.forEach((comparison) => moveTransferTime(comparison, -transferTime));
-
-  otherSplitComparisons?.forEach((comparison) => moveTransferTime(comparison, transferTime));
-
+  // only move aggregated pb time splitpoint at the middle split point.
+  // this keeps the aggregate length of the two splits the same.
+  if (nextSplit) {
+    currentSplitComparisons.forEach((comparison) => moveTransferTime(comparison, -transferTime));
+  } else {  
+    otherSplitComparisons?.forEach((comparison) => moveTransferTime(comparison, transferTime));
+  }
+  
   return [currentSplit, otherSplit];
 };
 

--- a/worker/offload.worker.ts
+++ b/worker/offload.worker.ts
@@ -53,7 +53,7 @@ const messageCallback = (e: MessageEvent<OffloadWorkerMessage>) => {
       out = generateSplitDetail(a[0]);
       break;
     case OffloadWorkerOperation.MOVE_TIME_TO_OTHER_SPLIT:
-      out = moveTime(a[0], a[1], a[2]);
+      out = moveTime(a[0], a[1], a[2], a[3]);
       break;
     case OffloadWorkerOperation.CUMULATE_ATTEMPT_TIMES_FOR_ALL_SPLITS:
       out = cumulateAttemptTimesForAllSplits(a[0]);


### PR DESCRIPTION
the livesplit personal best SplitTime is stored as the aggregate time for the entire run.
moveTime() adjusted this on both aggregate SplitTimes points involved, making .

ie. when moving time from one split to the previous, the result in the aggregate SplitTime would go from:
```
|------|-----\-----|----|
to
|------|---\---|    ----|
```

this doesnt break the comparison at large, but livesplit uses this to extrapolate a time based on the segment-to-segment aggregate and you'll have two completely wrong splits at the last of the adjusted splits, and the next split after.

only adjusting the middle SplitTime fixes that issue and instead makes the above example work like:
```
|------|-----\-----|----|
to
|------|---\-------|----|
```