### PR TITLE
Minor accessibility commit for screen readers

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -39,7 +39,7 @@
       </a> with help from these
       <a href="https://github.com/Webcretaire/LiveSplitAnalyzer/graphs/contributors" class="text-white font-weight-bold"
          target="_blank">
-        awesome contributors</a>. Its source code is available on
+        awesome contributors</a>. Its <a href="https://github.com/Webcretaire/LiveSplitAnalyzer" class="text-white" target="_blank">source code</a> is available on
       <a href="https://github.com/Webcretaire/LiveSplitAnalyzer" class="text-white font-weight-bold" target="_blank">
         GitHub</a>.
     </footer>


### PR DESCRIPTION
Made the source code link more descriptive by having "source code" be the name of it (the old "GitHub" link is still functional)